### PR TITLE
Fix misformatted saddle dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "saddle": "~0.0.2",
+    "saddle": "git://github.com/codeparty/saddle.git",
     "serialize-object": "~0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Version format is wrong. NPM can't install dependency.
