### PR TITLE
Fix templates relative lookup

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -285,14 +285,19 @@ Views.prototype.find = function(name, namespace) {
 
   // Relative lookup
   var segments = name.split(':');
+  var nameSegmentsAmount = segments.length;
   if (namespace) segments = namespace.split(':').concat(segments);
-  // Iterate through segments, leaving the last segment and removing the
-  // second to last segment to traverse up the namespaces
-  while (segments.length > 1) {
-    segments.splice(-2, 1);
-    var testName = segments.join(':');
-    var match = map[testName];
-    if (match) return match;
+  // Iterate through segments, leaving the {nameSegmentsAmount} segments and
+  // removing the second to {nameSegmentsAmount} segment to traverse up the
+  // namespaces. Decrease {nameSegmentsAmount} if not found and repeat again.
+  while (nameSegmentsAmount > 0) {
+    while (segments.length > nameSegmentsAmount) {
+      segments.splice(-1 - nameSegmentsAmount, 1);
+      var testName = segments.join(':');
+      var match = map[testName];
+      if (match) return match;
+    }
+    nameSegmentsAmount--;
   }
 };
 Views.prototype.register = function(name, source, options) {


### PR DESCRIPTION
When specified template name has more then one section relative lookup used only the last section of a name which was leading to improper behavior.

This is related to this issue:
https://github.com/codeparty/derby/issues/381
