### PR TITLE
Deprecate webkitMovementX / webkitMovementY

### DIFF
--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -75,6 +75,7 @@ function hasTemplateProperty(object) {
   if (!object) return false;
   if (global.Node && object instanceof global.Node) return false;
   for (var key in object) {
+    if (key === 'webkitMovementX' || key === 'webkitMovementY') continue;
     if (object[key] instanceof templates.Template) return true;
   }
   return false;


### PR DESCRIPTION
Skip over deprecated 'webkitMovementX' and 'webkitMovementY' keys, as `movementX` and `movementY` already exist on the object. Addresses the following deprecation warnings in Chrome Version 45.0.2454.101 (64-bit):
`'webkitMovementX' is deprecated. Please use 'movementX' instead.`
`'webkitMovementY' is deprecated. Please use 'movementY' instead.`

![screen shot 2015-10-13 at 10 07 20 am](https://cloud.githubusercontent.com/assets/6504944/10463566/2ac42e04-719a-11e5-8d4e-a30394a419e3.png)

Chrome warning added https://codereview.chromium.org/1145243010/. An alternative approach would be to delete the keys entirely.