### PR TITLE
Fix outerDepedency so it returns `undefined` instead of `[undefined]`…

### DIFF
--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -6,6 +6,7 @@ exports.lookup = lookup;
 exports.templateTruthy = templateTruthy;
 exports.pathSegments = pathSegments;
 exports.renderValue = renderValue;
+exports._outerDependency = outerDependency;
 exports.ExpressionMeta = ExpressionMeta;
 
 exports.Expression = Expression;
@@ -581,7 +582,9 @@ ScopedModelExpression.prototype.set = function(context, value) {
 
 function outerDependency(expression, context, forInnerPath) {
   if (forInnerPath) return;
-  return [expression.resolve(context)];
+  var val = expression.resolve(context);
+  if (typeof val === 'undefined') return;
+  return [val];
 }
 
 function concat(a, b) {

--- a/test/expressions.mocha.js
+++ b/test/expressions.mocha.js
@@ -1,0 +1,17 @@
+var expect = require('expect.js');
+var expressions = require('../lib/expressions');
+
+describe('Expressions', function() {
+
+  it('outerDepedency returns undefined if expression.resolve(context) returns undefined', function() {
+    var expression = {
+      resolve: function() {
+        return;
+      },
+    };
+    var context = {};
+    var forInnerPath = false;
+    expect(expressions._outerDependency(expression, context, forInnerPath)).equal(undefined);
+  });
+
+});


### PR DESCRIPTION
… when `expression.resolve(context)` returns `undefined`. The bug was causing BracketsExpression#dependencies to return `[undefined, <actual dep>]`, which FunctionExpression#dependencies interpreted as an empty array due to checking `argDependencies[0]`.

@nateps @ishbu 

The user-facing manifestation of this bug was certain bracket expressions like `{{someMap[someKey]}}` not updating on changes to `someKey`, if `someKey` was unset on initial render.