### PR TITLE
Support a().b(), $at(_path).fn(), new a().b() in expressions

### DIFF
--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -376,7 +376,8 @@ BracketsExpression.prototype.dependencies = function(context, forInnerPath) {
   return concat(concat(outer, inner), before);
 };
 
-function FnExpression(segments, args, afterSegments, meta) {
+function FnExpression(expression, segments, args, afterSegments, meta) {
+  this.expression = expression;
   this.segments = segments;
   this.args = args;
   this.afterSegments = afterSegments;
@@ -388,7 +389,7 @@ function FnExpression(segments, args, afterSegments, meta) {
 FnExpression.prototype = new Expression();
 FnExpression.prototype.type = 'FnExpression';
 FnExpression.prototype.serialize = function() {
-  return serializeObject.instance(this, this.segments, this.args, this.afterSegments, this.meta);
+  return serializeObject.instance(this, this.expression, this.segments, this.args, this.afterSegments, this.meta);
 };
 FnExpression.prototype.get = function(context) {
   var value = this.apply(context);
@@ -399,7 +400,19 @@ FnExpression.prototype.get = function(context) {
   return this._getPatch(context, value);
 };
 FnExpression.prototype.apply = function(context, extraInputs) {
-  var parent = this._lookupParent(context);
+  var parent;
+  if (this.expression) {
+    var upcomingValue = this.expression.get(context);
+    // fn()() case
+    if (!this.segments || this.segments.length === 0) {
+      var getFn = upcomingValue.get || upcomingValue;
+      return this._applyFn(getFn, context, extraInputs, null);
+    }
+    parent = lookup(this.parentSegments, upcomingValue);
+    if (!parent) return;
+  } else {
+    parent = this._lookupParent(context);
+  }
   var fn = parent[this.lastSegment];
   var getFn = fn.get || fn;
   var out = this._applyFn(getFn, context, extraInputs, parent);
@@ -484,8 +497,8 @@ FnExpression.prototype.set = function(context, value) {
   }
 };
 
-function NewExpression(segments, args, afterSegments, meta) {
-  FnExpression.call(this, segments, args, afterSegments, meta);
+function NewExpression(expression, segments, args, afterSegments, meta) {
+  FnExpression.call(this, expression, segments, args, afterSegments, meta);
 }
 NewExpression.prototype = new FnExpression();
 NewExpression.prototype.type = 'NewExpression';
@@ -551,20 +564,28 @@ SequenceExpression.prototype.dependencies = function(context, forInnerPath) {
   return dependencies;
 };
 
-function ScopedModelExpression(expression, meta) {
+function ScopedModelExpression(expression, afterSegments, meta) {
   this.expression = expression;
+  this.afterSegments = afterSegments;
   this.meta = meta;
 }
 ScopedModelExpression.prototype = new Expression();
 ScopedModelExpression.prototype.type = 'ScopedModelExpression';
 ScopedModelExpression.prototype.serialize = function() {
-  return serializeObject.instance(this, this.expression, this.meta);
+  return serializeObject.instance(this, this.expression, this.afterSegments, this.meta);
 };
 // Return a scoped model instead of the value
 ScopedModelExpression.prototype.get = function(context) {
   var segments = this.pathSegments(context);
   if (!segments) return;
-  return context.controller.model.scope(segments.join('.'));
+  var value = context.controller.model.scope(segments.join('.'));
+
+  // Lookup property underneath computed value if needed
+  if (this.afterSegments) {
+    value = lookup(this.afterSegments, value);
+  }
+
+  return value;
 };
 // Delegate other methods to the inner expression
 ScopedModelExpression.prototype.resolve = function(context) {

--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -212,21 +212,21 @@ PathExpression.prototype.dependencies = function(context, forInnerPath) {
   return outerDependency(this, context, forInnerPath);
 };
 
-function RelativePathExpression(segments, meta) {
-  this.segments = segments;
+function RelativePathExpression(afterSegments, meta) {
+  this.afterSegments = afterSegments;
   this.meta = meta;
 }
 RelativePathExpression.prototype = new Expression();
 RelativePathExpression.prototype.type = 'RelativePathExpression';
 RelativePathExpression.prototype.serialize = function() {
-  return serializeObject.instance(this, this.segments, this.meta);
+  return serializeObject.instance(this, this.afterSegments, this.meta);
 };
 RelativePathExpression.prototype.get = function(context) {
   var relativeContext = context.forRelative(this);
   var value = relativeContext.get();
-  if (this.segments.length) {
+  if (this.afterSegments.length) {
     value = renderTemplate(value, relativeContext);
-    value = lookup(this.segments, value);
+    value = lookup(this.afterSegments, value);
   }
   return this._getPatch(context, value);
 };
@@ -236,7 +236,7 @@ RelativePathExpression.prototype.resolve = function(context) {
     relativeContext.expression.resolve(relativeContext) :
     [];
   if (!base) return;
-  var segments = base.concat(this.segments);
+  var segments = base.concat(this.afterSegments);
   return this._resolvePatch(context, segments);
 };
 RelativePathExpression.prototype.dependencies = function(context, forInnerPath) {
@@ -249,15 +249,15 @@ RelativePathExpression.prototype.dependencies = function(context, forInnerPath) 
   return concat(outer, inner);
 };
 
-function AliasPathExpression(alias, segments, meta) {
+function AliasPathExpression(alias, afterSegments, meta) {
   this.alias = alias;
-  this.segments = segments;
+  this.afterSegments = afterSegments;
   this.meta = meta;
 }
 AliasPathExpression.prototype = new Expression();
 AliasPathExpression.prototype.type = 'AliasPathExpression';
 AliasPathExpression.prototype.serialize = function() {
-  return serializeObject.instance(this, this.alias, this.segments, this.meta);
+  return serializeObject.instance(this, this.alias, this.afterSegments, this.meta);
 };
 AliasPathExpression.prototype.get = function(context) {
   var aliasContext = context.forAlias(this.alias);
@@ -266,9 +266,9 @@ AliasPathExpression.prototype.get = function(context) {
     return aliasContext.item;
   }
   var value = aliasContext.get();
-  if (this.segments.length) {
+  if (this.afterSegments.length) {
     value = renderTemplate(value, aliasContext);
-    value = lookup(this.segments, value);
+    value = lookup(this.afterSegments, value);
   }
   return this._getPatch(context, value);
 };
@@ -278,7 +278,7 @@ AliasPathExpression.prototype.resolve = function(context) {
   if (aliasContext.keyAlias === this.alias) return;
   var base = aliasContext.expression.resolve(aliasContext);
   if (!base) return;
-  var segments = base.concat(this.segments);
+  var segments = base.concat(this.afterSegments);
   return this._resolvePatch(context, segments);
 };
 AliasPathExpression.prototype.dependencies = function(context, forInnerPath) {
@@ -296,23 +296,23 @@ AliasPathExpression.prototype.dependencies = function(context, forInnerPath) {
   return concat(outer, inner);
 };
 
-function AttributePathExpression(attribute, segments, meta) {
+function AttributePathExpression(attribute, afterSegments, meta) {
   this.attribute = attribute;
-  this.segments = segments;
+  this.afterSegments = afterSegments;
   this.meta = meta;
 }
 AttributePathExpression.prototype = new Expression();
 AttributePathExpression.prototype.type = 'AttributePathExpression';
 AttributePathExpression.prototype.serialize = function() {
-  return serializeObject.instance(this, this.attribute, this.segments, this.meta);
+  return serializeObject.instance(this, this.attribute, this.afterSegments, this.meta);
 };
 AttributePathExpression.prototype.get = function(context) {
   var attributeContext = context.forAttribute(this.attribute);
   if (!attributeContext) return;
   var value = attributeContext.attributes[this.attribute];
-  if (this.segments.length) {
+  if (this.afterSegments.length) {
     value = renderTemplate(value, attributeContext);
-    value = lookup(this.segments, value);
+    value = lookup(this.afterSegments, value);
   }
   return this._getPatch(context, value);
 };
@@ -323,7 +323,7 @@ AttributePathExpression.prototype.resolve = function(context) {
   var base = value && (typeof value.resolve === 'function') &&
     value.resolve(attributeContext);
   if (!base) return;
-  var segments = base.concat(this.segments);
+  var segments = base.concat(this.afterSegments);
   return this._resolvePatch(context, segments);
 };
 AttributePathExpression.prototype.dependencies = function(context, forInnerPath) {


### PR DESCRIPTION
The PR fix some lacks in derby-parser and derby-templates. 

After the commit the derby-parsing tests passed correctly:

```
  it('gets method call of the result of an fn expressions', function() {
    var expression = create('passThrough(_page.date).valueOf()');
    expect(expression.get(context)).to.equal(1000);
  });
  it('gets method call of the result of a `new` expressions', function() {
    var expression = create('new Date(1000).valueOf()');
    expect(expression.get(context)).to.equal(1000);
  });
  it('gets method call of a scoped model expression', function() {
    var expression = create('$at(_page.nums[3]).path()');
    expect(expression.get(context)).to.equal('_page.nums.3');
  });
```

Here is the corresponding derby-parsing PR - https://github.com/derbyjs/derby-parsing/pull/14

P.S. for sure it doesn't break anything. All the tests passed. 
