### PR TITLE
Maintain context with a ContextClosure for templates returned from expressions

### DIFF
--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -1,7 +1,7 @@
 var serializeObject = require('serialize-object');
 var operatorFns = require('./operatorFns');
-var ContextClosure = require('./templates').ContextClosure;
-var Template = require('./templates').Template;
+var templates = require('./templates');
+var Template = templates.Template;
 var util = require('./util');
 var concat = util.concat;
 
@@ -19,6 +19,7 @@ exports.RelativePathExpression = RelativePathExpression;
 exports.AliasPathExpression = AliasPathExpression;
 exports.AttributePathExpression = AttributePathExpression;
 exports.BracketsExpression = BracketsExpression;
+exports.DeferRenderExpression = DeferRenderExpression;
 exports.ArrayExpression = ArrayExpression;
 exports.ObjectExpression = ObjectExpression;
 exports.FnExpression = FnExpression;
@@ -183,7 +184,7 @@ Expression.prototype._lookupOrContextifyValue = function(value, context) {
   } else if (value instanceof Template) {
     // If we're not immediately rendering the template, then create a ContextClosure
     // so that the value renders with the correct context later.
-    value = new ContextClosure(value, context);
+    value = new templates.ContextClosure(value, context);
   }
   return value;
 };
@@ -398,6 +399,29 @@ BracketsExpression.prototype.dependencies = function(context, options) {
   var inner = this.inside.dependencies(context, options);
   var dependencies = concat(before, inner);
   return appendDependency(dependencies, this, context);
+};
+
+// This Expression is used to wrap a template so that when its containing
+// Expression--such as an ObjectExpression or ArrayExpression--is evaluated,
+// it returns the template unrendered and wrapped in the current context.
+// Separating evaluation of the containing expression from template rendering
+// is used to support array attributes of views. This way, we can evaluate an
+// array and iterate through it separately from rendering template content
+function DeferRenderExpression(template, meta) {
+  if (!(template instanceof Template)) {
+    throw new Error('DeferRenderExpression requires a Template argument');
+  }
+  this.template = template;
+  this.meta = meta;
+}
+DeferRenderExpression.prototype = Object.create(Expression.prototype);
+DeferRenderExpression.prototype.constructor = DeferRenderExpression;
+DeferRenderExpression.prototype.type = 'DeferRenderExpression';
+DeferRenderExpression.prototype.serialize = function() {
+  return serializeObject.instance(this, this.template, this.meta);
+};
+DeferRenderExpression.prototype.get = function(context) {
+  return new templates.ContextClosure(this.template, context);
 };
 
 function ArrayExpression(items, afterSegments, meta) {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -60,11 +60,21 @@ saddle.DynamicComment.prototype.dependencies = function(context, options) {
   if (DependencyOptions.shouldIgnoreTemplate(this, options)) return;
   return getDependencies(this.expression, context, options);
 };
+saddle.Html.prototype.dependencies = function() {};
+saddle.DynamicHtml.prototype.dependencies = function(context, options) {
+  if (DependencyOptions.shouldIgnoreTemplate(this, options)) return;
+  return getDependencies(this.expression, context, options);
+};
 saddle.Element.prototype.dependencies = function(context, options) {
   if (DependencyOptions.shouldIgnoreTemplate(this, options)) return;
   var dependencies = concatMapDependencies(null, this.attributes, context, options);
   if (!this.content) return dependencies;
   return concatArrayDependencies(dependencies, this.content, context, options);
+};
+saddle.DynamicElement.prototype.dependencies = function(context, options) {
+  if (DependencyOptions.shouldIgnoreTemplate(this, options)) return;
+  var dependencies = saddle.Element.prototype.dependencies(context, options);
+  return concatDependencies(dependencies, this.tagName, context, options);
 };
 saddle.Block.prototype.dependencies = function(context, options) {
   if (DependencyOptions.shouldIgnoreTemplate(this, options)) return;


### PR DESCRIPTION
Add ContextClosure around Templates that are returned from get() methods of Expressions that return a Template from another context. We need to keep the template associated with the context which it is from, so that the expressions it contains continue to refer to the same thing. Prior, we were returning the template without the associated context. Specifically, this affects RelativePathExpression, AliasPathExpression, and AttributePathExpression.

This fixes derbyjs/derby#551