### PR TITLE
implement equals method for equivalent ContextClosure objects

### DIFF
--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -174,14 +174,15 @@ Expression.prototype.isUnbound = function(context) {
   // Otherwise, inherit from the context
   return context.unbound;
 };
-Expression.prototype._lookupOrContextifyValue = function(value, context) {
+Expression.prototype._lookupAndContextifyValue = function(value, context) {
   if (this.segments && this.segments.length) {
     // If expression has segments, e.g. `bar.baz` in `#foo.bar.baz`, then
     // render the base value (e.g. `#foo`) if it's a template and look up the
     // value at the indicated path.
     value = renderTemplate(value, context);
     value = lookup(this.segments, value);
-  } else if (value instanceof Template) {
+  }
+  if (value instanceof Template && !(value instanceof templates.ContextClosure)) {
     // If we're not immediately rendering the template, then create a ContextClosure
     // so that the value renders with the correct context later.
     value = new templates.ContextClosure(value, context);
@@ -252,7 +253,7 @@ RelativePathExpression.prototype.serialize = function() {
 RelativePathExpression.prototype.get = function(context) {
   var relativeContext = context.forRelative(this);
   var value = relativeContext.get();
-  return this._lookupOrContextifyValue(value, relativeContext);
+  return this._lookupAndContextifyValue(value, relativeContext);
 };
 RelativePathExpression.prototype.resolve = function(context) {
   var relativeContext = context.forRelative(this);
@@ -290,7 +291,7 @@ AliasPathExpression.prototype.get = function(context) {
     return aliasContext.item;
   }
   var value = aliasContext.get();
-  return this._lookupOrContextifyValue(value, aliasContext);
+  return this._lookupAndContextifyValue(value, aliasContext);
 };
 AliasPathExpression.prototype.resolve = function(context) {
   var aliasContext = context.forAlias(this.alias);
@@ -335,7 +336,7 @@ AttributePathExpression.prototype.get = function(context) {
   if (value instanceof Expression) {
     value = value.get(attributeContext);
   }
-  return this._lookupOrContextifyValue(value, attributeContext);
+  return this._lookupAndContextifyValue(value, attributeContext);
 };
 AttributePathExpression.prototype.resolve = function(context) {
   var attributeContext = context.forAttribute(this.attribute);

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,8 +1,16 @@
+var templates = require('./templates');
+
 exports.DependencyOptions = DependencyOptions;
 
 function DependencyOptions(options) {
-  this.ignoreTemplate = options && options.ignoreTemplate;
+  this.setIgnoreTemplate(options && options.ignoreTemplate);
 }
 DependencyOptions.shouldIgnoreTemplate = function(template, options) {
   return (options) ? options.ignoreTemplate === template : false;
+};
+DependencyOptions.prototype.setIgnoreTemplate = function(template) {
+  while (template instanceof templates.ContextClosure) {
+    template = template.template;
+  }
+  this.ignoreTemplate = template;
 };

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -439,7 +439,7 @@ ContextClosure.prototype.attachTo = function(parent, node, context) {
   return this.template.attachTo(parent, node, closureContext);
 };
 ContextClosure.prototype.dependencies = function(context, options) {
-  if (DependencyOptions.shouldIgnoreTemplate(this, options)) return;
+  if (DependencyOptions.shouldIgnoreTemplate(this.template, options)) return;
   var closureContext = context.closureChild(this.context);
   return this.template.dependencies(closureContext, options);
 };

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -443,6 +443,11 @@ ContextClosure.prototype.dependencies = function(context, options) {
   var closureContext = context.closureChild(this.context);
   return this.template.dependencies(closureContext, options);
 };
+ContextClosure.prototype.equals = function(other) {
+  return (other instanceof ContextClosure) &&
+    (other.template === this.template) &&
+    (other.context === this.context);
+};
 
 function ViewsMap() {}
 function Views() {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -445,8 +445,8 @@ ContextClosure.prototype.dependencies = function(context, options) {
 };
 ContextClosure.prototype.equals = function(other) {
   return (other instanceof ContextClosure) &&
-    (other.template === this.template) &&
-    (other.context === this.context);
+    (this.context === other.context) &&
+    (this.template.equals(other.template));
 };
 
 function ViewsMap() {}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Nate Smith",
   "license": "MIT",
   "dependencies": {
-    "saddle": "^0.9.1",
+    "saddle": "^0.9.4",
     "serialize-object": "^1.0.0"
   },
   "bugs": {


### PR DESCRIPTION
Resolve issue with determining if the same template is being rendered and binding should not update (because the template has not changed). This issue was created because the template was wrapped in a new ContextClosure object.

Solution is to override the base `Template#equals` method (added in https://github.com/derbyjs/saddle/pull/27) with `ContextClosure#equals`, which treats ContextClosures as equal if they have the same template and context properties - meaning they would render identical output in all cases. This fixes issues with over-rendering.

This also has `DependencyOptions` fully unwrap its `ignoreTemplate` field if the field is a ContextClosure, as `DepedencyOptions.shouldIgnoreTemplate(template, options)` will always get a `template` generated by derby-parsing, which means it will never get a ContextClosure.