### PR TITLE
Fix leaks: Improve cleanup of references when nodes are removed from DOM

### DIFF
--- a/lib/contexts.js
+++ b/lib/contexts.js
@@ -57,6 +57,7 @@ function Context(meta, controller, parent, unbound, expression) {
 
   // Used in EventModel
   this._id = null;
+  this._eventModels = null;
 }
 
 Context.prototype.id = function() {

--- a/lib/contexts.js
+++ b/lib/contexts.js
@@ -3,9 +3,6 @@ exports.Context = Context;
 
 function noop() {}
 
-// TODO:
-// Implement removeItemContext
-
 function ContextMeta() {
   this.addBinding = noop;
   this.removeBinding = noop;
@@ -81,7 +78,22 @@ Context.prototype.removeBinding = function(binding) {
   this.meta.removeBinding(binding);
 };
 Context.prototype.removeNode = function(node) {
-  this.meta.removeNode(node);
+  var bindItemStart = node.$bindItemStart;
+  if (bindItemStart) {
+    this.meta.removeItemContext(bindItemStart.context);
+  }
+  var component = node.$component;
+  if (component && !component.singleton) {
+    component.destroy();
+  }
+  var destroyListeners = node.$destroyListeners;
+  if (destroyListeners) {
+    for (var i = 0; i < destroyListeners.length; i++) {
+      destroyListeners[i]();
+    }
+    node.$destroyListeners = null;
+  }
+  if (node.$component) node.$component = null;
 };
 
 Context.prototype.child = function(expression) {

--- a/lib/contexts.js
+++ b/lib/contexts.js
@@ -84,17 +84,19 @@ Context.prototype.removeNode = function(node) {
     this.meta.removeItemContext(bindItemStart.context);
   }
   var component = node.$component;
-  if (component && !component.singleton) {
-    component.destroy();
+  if (component) {
+    node.$component = null;
+    if (!component.singleton) {
+      component.destroy();
+    }
   }
   var destroyListeners = node.$destroyListeners;
   if (destroyListeners) {
-    for (var i = 0; i < destroyListeners.length; i++) {
+    node.$destroyListeners = null;
+    for (var i = 0, len = destroyListeners.length; i < len; i++) {
       destroyListeners[i]();
     }
-    node.$destroyListeners = null;
   }
-  if (node.$component) node.$component = null;
 };
 
 Context.prototype.child = function(expression) {

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -560,12 +560,6 @@ ElementOn.prototype.emit = function(context, element) {
     this.apply(context, element);
     return;
   }
-
-  // } else if (this.name === 'destroy') {
-  //   elementAddDestroyListener(element, function elementOnDestroy() {
-  //     elementOn.apply(context, element);
-  //   });
-
   var elementOn = this;
   var listener = function elementOnListener(event) {
     return elementOn.apply(context, element, event);

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -283,7 +283,7 @@ View.prototype.dependencies = function(context, options) {
 };
 View.prototype.parse = function() {
   this._parse();
-  if (this.componentFactory) {
+  if (this.componentFactory && !this.componentFactory.constructor.prototype.singleton) {
     var marker = new Marker(this.name);
     this.template.content.unshift(marker);
   }

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -563,7 +563,7 @@ ElementOn.prototype.emit = function(context, element) {
     });
 
   } else {
-    element.addEventListener(this.name, function elementOnListener(event) {
+    context.controller.dom.on(this.name, element, function elementOnListener(event) {
       return elementOn.apply(context, element, event);
     }, false);
   }

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -33,6 +33,9 @@ exports.AsArrayComponent = AsArrayComponent;
 
 exports.emptyTemplate = new saddle.Template([]);
 
+exports.elementAddDestroyListener = elementAddDestroyListener;
+exports.elementRemoveDestroyListener = elementRemoveDestroyListener;
+
 // Add ::isUnbound to Template && Binding
 saddle.Template.prototype.isUnbound = function(context) {
   return context.unbound;
@@ -685,8 +688,7 @@ AsArray.prototype.emit = function(context, target) {
 };
 AsArray.prototype.addListeners = function(target, array) {
   this.addDestroyListener(target, function asArrayDestroy() {
-    var index = array.indexOf(target);
-    if (index !== -1) array.splice(index, 1);
+    removeArrayItem(array, target);
   });
 };
 AsArray.prototype.comparePosition = function(target, item) {
@@ -707,11 +709,25 @@ AsArrayComponent.prototype.addDestroyListener = componentAddDestroyListener;
 function elementAddDestroyListener(element, listener) {
   var destroyListeners = element.$destroyListeners;
   if (destroyListeners) {
-    destroyListeners.push(listener);
+    if (destroyListeners.indexOf(listener) === -1) {
+      destroyListeners.push(listener);
+    }
   } else {
     element.$destroyListeners = [listener];
   }
 }
+function elementRemoveDestroyListener(element, listener) {
+  var destroyListeners = element.$destroyListeners;
+  if (destroyListeners) {
+    removeArrayItem(destroyListeners, listener);
+  }
+}
 function componentAddDestroyListener(target, listener) {
   target.on('destroy', listener);
+}
+function removeArrayItem(array, item) {
+  var index = array.indexOf(item);
+  if (index > -1) {
+    array.splice(index, 1);
+  }
 }

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -25,6 +25,7 @@ exports.MarkupHook = MarkupHook;
 exports.ElementOn = ElementOn;
 exports.ComponentOn = ComponentOn;
 exports.AsProperty = AsProperty;
+exports.AsPropertyComponent = AsPropertyComponent;
 exports.AsObject = AsObject;
 exports.AsObjectComponent = AsObjectComponent;
 exports.AsArray = AsArray;
@@ -610,7 +611,22 @@ AsProperty.prototype.serialize = function() {
 AsProperty.prototype.emit = function(context, target) {
   var node = traverseAndCreate(context.controller, this.segments);
   node[this.lastSegment] = target;
+  this.addListeners(target, node, this.lastSegment);
 };
+AsProperty.prototype.addListeners = function(target, object, key) {
+  this.addDestroyListener(target, function asPropertyDestroy() {
+    delete object[key];
+  });
+};
+AsProperty.prototype.addDestroyListener = elementAddDestroyListener;
+
+function AsPropertyComponent(segments) {
+  AsProperty.call(this, segments);
+}
+AsPropertyComponent.prototype = Object.create(AsProperty.prototype);
+AsPropertyComponent.prototype.constructor = AsPropertyComponent;
+AsPropertyComponent.prototype.type = 'AsPropertyComponent';
+AsPropertyComponent.prototype.addDestroyListener = componentAddDestroyListener;
 
 function AsObject(segments, keyExpression) {
   AsProperty.call(this, segments);
@@ -630,15 +646,6 @@ AsObject.prototype.emit = function(context, target) {
   object[key] = target;
   this.addListeners(target, object, key);
 };
-AsObject.prototype.addListeners = function(target, object, key) {
-  this.addDestroyListener(target, function asObjectDestroy() {
-    delete object[key];
-  });
-};
-AsObject.prototype.addDestroyListener = function(target, listener) {
-  var listeners = target.$destroyListeners || (target.$destroyListeners = []);
-  listeners.push(listener);
-};
 
 function AsObjectComponent(segments, keyExpression) {
   AsObject.call(this, segments, keyExpression);
@@ -646,9 +653,7 @@ function AsObjectComponent(segments, keyExpression) {
 AsObjectComponent.prototype = Object.create(AsObject.prototype);
 AsObjectComponent.prototype.constructor = AsObjectComponent;
 AsObjectComponent.prototype.type = 'AsObjectComponent';
-AsObjectComponent.prototype.addDestroyListener = function(target, listener) {
-  target.on('destroy', listener);
-};
+AsObjectComponent.prototype.addDestroyListener = componentAddDestroyListener;
 
 function AsArray(segments) {
   AsProperty.call(this, segments);
@@ -688,7 +693,6 @@ AsArray.prototype.addListeners = function(target, array) {
 AsArray.prototype.comparePosition = function(target, item) {
   return item.compareDocumentPosition(target);
 };
-AsArray.prototype.addDestroyListener = AsObject.prototype.addDestroyListener;
 
 function AsArrayComponent(segments) {
   AsArray.call(this, segments);
@@ -699,4 +703,12 @@ AsArrayComponent.prototype.type = 'AsArrayComponent';
 AsArrayComponent.prototype.comparePosition = function(target, item) {
   return item.markerNode.compareDocumentPosition(target.markerNode);
 };
-AsArrayComponent.prototype.addDestroyListener = AsObjectComponent.prototype.addDestroyListener;
+AsArrayComponent.prototype.addDestroyListener = componentAddDestroyListener;
+
+function elementAddDestroyListener(target, listener) {
+  var listeners = target.$destroyListeners || (target.$destroyListeners = []);
+  listeners.push(listener);
+}
+function componentAddDestroyListener(target, listener) {
+  target.on('destroy', listener);
+}

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -558,8 +558,7 @@ ElementOn.prototype.emit = function(context, element) {
     this.apply(context, element);
 
   } else if (this.name === 'destroy') {
-    var destroyListeners = element.$destroyListeners || (element.$destroyListeners = []);
-    destroyListeners.push(function elementOnDestroy() {
+    elementAddDestroyListener(element, function elementOnDestroy() {
       elementOn.apply(context, element);
     });
 
@@ -705,9 +704,13 @@ AsArrayComponent.prototype.comparePosition = function(target, item) {
 };
 AsArrayComponent.prototype.addDestroyListener = componentAddDestroyListener;
 
-function elementAddDestroyListener(target, listener) {
-  var listeners = target.$destroyListeners || (target.$destroyListeners = []);
-  listeners.push(listener);
+function elementAddDestroyListener(element, listener) {
+  var destroyListeners = element.$destroyListeners;
+  if (destroyListeners) {
+    destroyListeners.push(listener);
+  } else {
+    element.$destroyListeners = [listener];
+  }
 }
 function componentAddDestroyListener(target, listener) {
   target.on('destroy', listener);

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -556,20 +556,21 @@ ElementOn.prototype.serialize = function() {
   return serializeObject.instance(this, this.name, this.expression);
 };
 ElementOn.prototype.emit = function(context, element) {
-  var elementOn = this;
   if (this.name === 'create') {
     this.apply(context, element);
-
-  } else if (this.name === 'destroy') {
-    elementAddDestroyListener(element, function elementOnDestroy() {
-      elementOn.apply(context, element);
-    });
-
-  } else {
-    context.controller.dom.on(this.name, element, function elementOnListener(event) {
-      return elementOn.apply(context, element, event);
-    }, false);
+    return;
   }
+
+  // } else if (this.name === 'destroy') {
+  //   elementAddDestroyListener(element, function elementOnDestroy() {
+  //     elementOn.apply(context, element);
+  //   });
+
+  var elementOn = this;
+  var listener = function elementOnListener(event) {
+    return elementOn.apply(context, element, event);
+  };
+  context.controller.dom.on(this.name, element, listener, false);
 };
 ElementOn.prototype.apply = function(context, element, event) {
   var modelData = context.controller.model.data;


### PR DESCRIPTION
Make a few changes to resolve sources of memory leaks from dangling references:
* Improve cleanup of references created by `on-` and `as` in templates. This will now remove references created by `as` in templates, which could lead to issues if there are async callbacks that expect the nodes references to be there without checking
* Cleanup item bindings within each blocks when the relevant DOM nodes are removed
* Do a better job of factoring code by moving items related to element destroy listeners into this module.