### PR TITLE
Defer delete with nextTick

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -633,8 +633,11 @@ AsProperty.prototype.emit = function(context, target) {
   this.addListeners(target, node, this.lastSegment);
 };
 AsProperty.prototype.addListeners = function(target, object, key) {
-  this.addDestroyListener(target, function asPropertyDestroy() {
+  var deleteProperty = function () {
     delete object[key];
+  }
+  this.addDestroyListener(target, function asPropertyDestroy() {
+    process.nextTick(deleteProperty);
   });
 };
 AsProperty.prototype.addDestroyListener = elementAddDestroyListener;


### PR DESCRIPTION
Defer removal of reference to next tick to resolve issues in tests doing synchronous checks requiring valid reference