### PR TITLE
Fix deferred destroy

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -633,11 +633,16 @@ AsProperty.prototype.emit = function(context, target) {
   this.addListeners(target, node, this.lastSegment);
 };
 AsProperty.prototype.addListeners = function(target, object, key) {
-  var deleteProperty = function () {
-    delete object[key];
-  }
   this.addDestroyListener(target, function asPropertyDestroy() {
-    process.nextTick(deleteProperty);
+    // memoize initial reference so we dont destroy
+    // property that has been replaced with a different reference
+    var intialRef = object[key];
+    process.nextTick(function deleteProperty() {
+      if (intialRef !== object[key]) {
+        return;
+      }
+      delete object[key];
+    });
   });
 };
 AsProperty.prototype.addDestroyListener = elementAddDestroyListener;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "derby-templates",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha && ./node_modules/.bin/jshint lib/*.js test/*.js"


### PR DESCRIPTION
Deferring the destroy of an `as` property reference would cause the deletion of the property even if the property had been changed to use a new reference e.g. where conditional rendering would replace a property with another component.

This fix add guard checking the reference is unchanged before deleting