### PR TITLE
Switch ElementOn back to addEventListener instead of dom.on

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -586,7 +586,13 @@ ElementOn.prototype.emit = function(context, element) {
   var listener = function elementOnListener(event) {
     return elementOn.apply(context, element, event);
   };
-  context.controller.dom.on(this.name, element, listener, false);
+  // Using `context.controller.dom.on` would be better for garbage collection,
+  // but since it synchronously removes listeners on component destroy, it would
+  // break existing code relying on `on-*` listeners firing as a component is
+  // being destroyed. Even with `addEventListener`, browsers should still GC
+  // the listeners once there are no references to the element.
+  element.addEventListener(this.name, listener, false);
+  // context.controller.dom.on(this.name, element, listener, false);
 };
 ElementOn.prototype.apply = function(context, element, event) {
   var modelData = context.controller.model.data;


### PR DESCRIPTION
This undoes 7c6d9b9, since using `dom.on` was causing some undocumented breakages in code relying on `on-*` listeners firing as a component is being destroyed.

Longer-term fix might involve deferring the event listener cleanup, but it's not a huge deal since Derby-rendered HTML elements will usually have no references to them once the containing component is destroyed, anyways.